### PR TITLE
Fix bugs in filterModel

### DIFF
--- a/src/selement/selementAssociation.ts
+++ b/src/selement/selementAssociation.ts
@@ -6,6 +6,46 @@ class SElementAssociation {
   deptype?: string;
   attrs?: any;
 
+  /**
+     Create association between two elements if there already does not exist a similar association.
+     The association is considered to be similar if toElement has an incoming association with the
+     same type and the same fromElement.
+     @param {SElement} fromElement the elemenet that is the starting point of the association
+     @param {SElement} toElement the element that is the ending point of the association
+     @param {string} deptype the type of the association
+     @param {any} depattrs attributes for the associtaion
+     @returns {SElement, boolean} Return an object containing the existing or new element and a 
+     boolean indicating if a new element was created (true if new was created, false otherwise)
+   */
+  static createUniqueElementAssociation(
+    fromElement: SElement,
+    toElement: SElement,
+    deptype?: any,
+    depattrs: any = {}
+  ): { existingOrNewAssociation: SElementAssociation; isNew: boolean } {
+    const existingAssociations = toElement.incoming.filter((incoming) => {
+      const fromElementMatches = incoming.fromElement === fromElement;
+      return deptype
+        ? deptype === incoming.deptype && fromElementMatches
+        : fromElementMatches;
+    });
+    // Do not create association if the same association already exists
+    if (existingAssociations.length > 0) {
+      return {
+        existingOrNewAssociation: existingAssociations[0],
+        isNew: false,
+      };
+    }
+    const newAssociation = new SElementAssociation(
+      fromElement,
+      toElement,
+      deptype,
+      depattrs
+    );
+    newAssociation.initElems();
+    return { existingOrNewAssociation: newAssociation, isNew: true };
+  }
+
   constructor(from: SElement, to: SElement, deptype?: any, depattrs: any = {}) {
     this.fromElement = from;
     this.toElement = to;

--- a/test/nginx_model.xml
+++ b/test/nginx_model.xml
@@ -16,8 +16,12 @@
     <e n="foo" >
       <e n="bar" >
         <e n="test" >
-           <e n="test1" />
-           <e n="test2" />
+           <e i="8" n="test1" ></e>
+           <e n="test2" ></e>
+        </e>
+        <e n="testing" >
+          <r r="8" t="inc1" />
+          <r r="8" t="inc2" />
         </e>
       </e>
     </e>


### PR DESCRIPTION
- Fix missing attributes after filterModel by replacing elem with child in loop going through attributes
- Fix infinite loop problem by changing data type of stack to Set
- Fix duplicate associations by introducing new function for creating associations. This function checks for existing association before creating a new one.