### PR TITLE
Fix getChildByName implementation

### DIFF
--- a/dist/modelapi.js
+++ b/dist/modelapi.js
@@ -135,7 +135,10 @@ class ModelApi {
                     for (const child of elem.children) {
                         subGraphStack.push(child);
                         if (correspondingSourceElement) {
-                            wholeGraphStack.push(correspondingSourceElement.getChildByName(child.name));
+                            const childElement = correspondingSourceElement.getChildByName(child.name);
+                            if (childElement) {
+                                wholeGraphStack.push(childElement);
+                            }
                         }
                     }
                 }

--- a/dist/selement/selement.d.ts
+++ b/dist/selement/selement.d.ts
@@ -16,7 +16,7 @@ declare class SElement {
     addChild(child: SElement): SElement | undefined;
     merge(other: SElement, ignoreType?: boolean, ignoreAttrs?: boolean): void;
     detachChild(child: SElement): void;
-    getChildByName: (name: string) => SElement;
+    getChildByName: (name: string) => SElement | undefined;
     findElement(name: string): SElement | undefined;
     createOrGetElement(n: string): SElement;
     createElementChain(id: string): SElement;

--- a/dist/selement/selement.js
+++ b/dist/selement/selement.js
@@ -26,7 +26,12 @@ class SElement {
         this.childrenObject = {};
         this.outgoing = [];
         this.incoming = [];
-        this.getChildByName = (name) => this.childrenObject[name];
+        this.getChildByName = (name) => {
+            if (Object.getOwnPropertyNames(this.childrenObject).includes(name)) {
+                return this.childrenObject[name];
+            }
+            return undefined;
+        };
         this.getHash = () => this.hash;
         if (parent && this.equals(parent)) {
             throw new Error('Self loop in model\n');

--- a/src/modelapi.ts
+++ b/src/modelapi.ts
@@ -242,9 +242,12 @@ class ModelApi {
         for (const child of elem.children) {
           subGraphStack.push(child);
           if (correspondingSourceElement) {
-            wholeGraphStack.push(
-              correspondingSourceElement.getChildByName(child.name)
+            const childElement = correspondingSourceElement.getChildByName(
+              child.name
             );
+            if (childElement) {
+              wholeGraphStack.push(childElement);
+            }
           }
         }
       }

--- a/src/selement/selement.ts
+++ b/src/selement/selement.ts
@@ -194,7 +194,12 @@ class SElement {
     this.updateHash();
   }
 
-  getChildByName = (name: string) => this.childrenObject[name];
+  getChildByName = (name: string): SElement | undefined => {
+    if (Object.getOwnPropertyNames(this.childrenObject).includes(name)) {
+      return this.childrenObject[name];
+    }
+    return undefined;
+  };
 
   findElement(name: string): SElement | undefined {
     if (name.startsWith('/')) {

--- a/test/selement/selement.test.ts
+++ b/test/selement/selement.test.ts
@@ -1,0 +1,15 @@
+import { SElement } from '../../src/selement';
+describe('selement tests', () => {
+  it('selement getChildByName should return undefined if child is not defined', () => {
+    const element = new SElement('test', undefined);
+    expect(element.getChildByName('valueOf')).toBeUndefined();
+    expect(element.getChildByName('toString')).toBeUndefined();
+  });
+  it('selement getChildByName should return correct child', () => {
+    const element = new SElement('test', undefined);
+    const child = new SElement('child', element);
+    const anotherChild = new SElement('anotherchild', element);
+    expect(element.getChildByName('child')).toEqual(child);
+    expect(element.getChildByName('anotherchild')).toEqual(anotherChild);
+  });
+});


### PR DESCRIPTION
getChildByName should not return anything that is not an own property of children object.

Fixes #8 