### PR TITLE
Combine attributes

### DIFF
--- a/dist/selement/selementAssociation.d.ts
+++ b/dist/selement/selementAssociation.d.ts
@@ -3,7 +3,7 @@ declare class SElementAssociation {
     fromElement: SElement;
     toElement: SElement;
     deptype?: string;
-    attrs?: any;
+    attrs?: Record<string, string>;
     /**
        Create association between two elements if there already does not exist a similar association.
        The association is considered to be similar if toElement has an incoming association with the
@@ -15,7 +15,7 @@ declare class SElementAssociation {
        @returns {SElement, boolean} Return an object containing the existing or new element and a
        boolean indicating if a new element was created (true if new was created, false otherwise)
      */
-    static createUniqueElementAssociation(fromElement: SElement, toElement: SElement, deptype?: any, depattrs?: any): {
+    static createUniqueElementAssociation(fromElement: SElement, toElement: SElement, deptype?: any, depattrs?: Record<string, string>): {
         existingOrNewAssociation: SElementAssociation;
         isNew: boolean;
     };
@@ -30,6 +30,6 @@ declare class SElementAssociation {
     getFromPath: () => string;
     getToPath: () => string;
     getType: () => string | undefined;
-    getAttributes: () => any;
+    getAttributes: () => Record<string, string> | undefined;
 }
 export { SElementAssociation };

--- a/dist/selement/selementAssociation.js
+++ b/dist/selement/selementAssociation.js
@@ -33,6 +33,19 @@ class SElementAssociation {
         });
         // Do not create association if the same association already exists
         if (existingAssociations.length > 0) {
+            // Combine attributes to the existing association
+            const existingAttributes = existingAssociations[0].getAttributes();
+            if (existingAttributes) {
+                // Check that there aren't same attributes with different values
+                Object.keys(depattrs).forEach((attributeName) => {
+                    if (Object.keys(existingAttributes).includes(attributeName)) {
+                        if (existingAttributes[attributeName] !== depattrs[attributeName]) {
+                            throw new SElementAssociationException(`Can not create association of type ${deptype} from ${fromElement.name} to ${toElement.name} due to attribute conflict: attribute with name ${attributeName} ${existingAttributes[attributeName]} would be replaced by ${depattrs[attributeName]}`);
+                        }
+                    }
+                });
+            }
+            existingAssociations[0].setAttrs(Object.assign(Object.assign({}, existingAttributes), depattrs));
             return {
                 existingOrNewAssociation: existingAssociations[0],
                 isNew: false,
@@ -43,13 +56,15 @@ class SElementAssociation {
         return { existingOrNewAssociation: newAssociation, isNew: true };
     }
     calculateCompareStatus() {
-        const compare = this.attrs['compare'];
-        if (compare === 'added')
-            return 1;
-        if (compare === 'removed')
-            return 2;
-        if (compare === 'changed')
-            return 3;
+        if (this.attrs) {
+            const compare = this.attrs['compare'];
+            if (compare === 'added')
+                return 1;
+            if (compare === 'removed')
+                return 2;
+            if (compare === 'changed')
+                return 3;
+        }
         return 0;
     }
     initElems() {
@@ -89,3 +104,9 @@ class SElementAssociation {
     }
 }
 exports.SElementAssociation = SElementAssociation;
+class SElementAssociationException extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'SElemenAssociationException';
+    }
+}

--- a/src/selement/selementAssociation.ts
+++ b/src/selement/selementAssociation.ts
@@ -31,6 +31,9 @@ class SElementAssociation {
     });
     // Do not create association if the same association already exists
     if (existingAssociations.length > 0) {
+      // Combine attributes to the existing association
+      const existingAttributes = existingAssociations[0].getAttributes();
+      existingAssociations[0].setAttrs({ ...existingAttributes, ...depattrs });
       return {
         existingOrNewAssociation: existingAssociations[0],
         isNew: false,

--- a/test/selement/selementAssociation.test.ts
+++ b/test/selement/selementAssociation.test.ts
@@ -62,6 +62,23 @@ describe('selement association tests', () => {
       attribute2: 'value2',
     });
   });
+  it('should throw an exception if trying to create an association with the same type and the same attribute but different value', () => {
+    const { element1, element2 } = createGraphAndElements();
+    SElementAssociation.createUniqueElementAssociation(
+      element1,
+      element2,
+      'deptype',
+      { attribute: 'value1' }
+    );
+    expect(() =>
+      SElementAssociation.createUniqueElementAssociation(
+        element1,
+        element2,
+        'deptype',
+        { attribute: 'value2' }
+      )
+    ).toThrow(Error);
+  });
 });
 
 const createGraphAndElements = () => {

--- a/test/selement/selementAssociation.test.ts
+++ b/test/selement/selementAssociation.test.ts
@@ -1,0 +1,72 @@
+import { SElement, SElementAssociation } from '../../src/selement';
+import { SGraph } from '../../src/sgraph';
+describe('selement association tests', () => {
+  it('should not create the same association twice', () => {
+    const { element1, element2 } = createGraphAndElements();
+    SElementAssociation.createUniqueElementAssociation(
+      element1,
+      element2,
+      '',
+      {}
+    );
+    expect(element1.outgoing.length).toBe(1);
+    expect(element2.incoming.length).toBe(1);
+    SElementAssociation.createUniqueElementAssociation(
+      element1,
+      element2,
+      '',
+      {}
+    );
+    expect(element1.outgoing.length).toBe(1);
+    expect(element2.incoming.length).toBe(1);
+  });
+  it('should create the association twice if deptype is different', () => {
+    const { element1, element2 } = createGraphAndElements();
+    SElementAssociation.createUniqueElementAssociation(
+      element1,
+      element2,
+      'deptype1',
+      {}
+    );
+    expect(element1.outgoing.length).toBe(1);
+    expect(element2.incoming.length).toBe(1);
+    SElementAssociation.createUniqueElementAssociation(
+      element1,
+      element2,
+      'deptype2',
+      {}
+    );
+    expect(element1.outgoing.length).toBe(2);
+    expect(element1.outgoing[0].deptype).toBe('deptype1');
+    expect(element1.outgoing[1].deptype).toBe('deptype2');
+    expect(element2.incoming.length).toBe(2);
+    expect(element2.incoming[0].deptype).toBe('deptype1');
+    expect(element2.incoming[1].deptype).toBe('deptype2');
+  });
+  it('should combine attributes of the associations', () => {
+    const { element1, element2 } = createGraphAndElements();
+    SElementAssociation.createUniqueElementAssociation(
+      element1,
+      element2,
+      'deptype',
+      { attribute1: 'value1' }
+    );
+    SElementAssociation.createUniqueElementAssociation(
+      element1,
+      element2,
+      'deptype',
+      { attribute2: 'value2' }
+    );
+    expect(element1.outgoing[0].getAttributes()).toEqual({
+      attribute1: 'value1',
+      attribute2: 'value2',
+    });
+  });
+});
+
+const createGraphAndElements = () => {
+  const graph = new SGraph(new SElement('root', undefined));
+  const element1 = graph.createOrGetElementFromPath('/test/element1');
+  const element2 = graph.createOrGetElementFromPath('/test/element2');
+  return { element1, element2 };
+};


### PR DESCRIPTION
Combine attributes when creating an association and an existing one is already found. Throw an exception if attribute values conflict.

Closes #7 